### PR TITLE
First Draft of Creating New JSON Files for Ammo Types 

### DIFF
--- a/json/ammo/cartridges.json
+++ b/json/ammo/cartridges.json
@@ -1,0 +1,26 @@
+{
+    "Name ": "Cartridge",
+    "description": "Ammunition used",
+    "type": "object",
+    "properties":
+    {
+       "name":
+       {
+          "description": "Name of Cartridge",
+          "type": "string",
+          "value": "Cartrige"
+       },
+       "caliber":
+       {
+          "description": "Diameter of bullet used in cartridge",
+          "type": "number",
+          "value": ".308"
+       },
+       "type":
+       {
+          "description": "Ammuntition is classified to be used in/what firearms/role",
+          "type": "string",
+          "value": "rifle"
+       }
+    }
+ }

--- a/json/ammo/loadData.json
+++ b/json/ammo/loadData.json
@@ -1,0 +1,30 @@
+{
+    "title": "LoadData",
+    "description": "Load Data used for particular calbier",
+    "type": "object",
+    "properties":
+    {
+       "bullet":
+       {
+          "manufacturer" : "Sierra",
+          "description": "Bullet used for load data",
+          "diameter": ".308",
+          "profile": "FMJ",
+          "weight": "150"
+       },
+       "powder":
+       {
+          "manufacturer" : "Hodgdon",
+          "description": "Powder used in load data",
+          "powderType": "Stick",
+          "powdercharge": "43.5",
+          "compressedLoad": "false"
+       },
+       "Primer":
+       {
+           "manufacturer" : "CCI",
+           "model" : "400",
+           "primerType": "Large rifle",
+       }
+    }, 
+ }


### PR DESCRIPTION
created two types of json concerning ammo; loadData.json is to be used referencing any existing entries inside cartridges.json